### PR TITLE
[RDY] Feat: Browser support check for WASM

### DIFF
--- a/wasm_support_check/.gitignore
+++ b/wasm_support_check/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.cache
+package-lock.json

--- a/wasm_support_check/package.json
+++ b/wasm_support_check/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "wasm_check",
+  "version": "1.0.0",
+  "description": "Checking wasm capabailities in node and browser",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel src/index.html",
+    "cli": "node src/index.js"
+  },
+  "author": "Mohammad Yousuf Minhaj Zia",
+  "license": "ISC",
+  "dependencies": {
+    "parcel-bundler": "^1.12.5",
+    "wasm-check": "^2.0.1"
+  }
+}

--- a/wasm_support_check/src/index.html
+++ b/wasm_support_check/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>WASM Check</title>
+  </head>
+  <body>
+    <script defer src="./index.js"></script>
+  </body>
+</html>

--- a/wasm_support_check/src/index.js
+++ b/wasm_support_check/src/index.js
@@ -1,5 +1,7 @@
-import * as check from 'wasm-check';
+// import * as check from 'wasm-check';
+const check = require('wasm-check');
 
 console.log(`WASM Support: ${check.support()}`);
+console.log(`WASM 2 Support: ${check.support(2)}`);
 console.log(`Features:`);
 console.log({...check.feature});

--- a/wasm_support_check/src/index.js
+++ b/wasm_support_check/src/index.js
@@ -2,6 +2,5 @@
 const check = require('wasm-check');
 
 console.log(`WASM Support: ${check.support()}`);
-console.log(`WASM 2 Support: ${check.support(2)}`);
 console.log(`Features:`);
 console.log({...check.feature});

--- a/wasm_support_check/src/index.js
+++ b/wasm_support_check/src/index.js
@@ -1,0 +1,5 @@
+import * as check from 'wasm-check';
+
+console.log(`WASM Support: ${check.support()}`);
+console.log(`Features:`);
+console.log({...check.feature});


### PR DESCRIPTION
Check support for web assembly features like tail calls exceptions, threads in a browser.
Launch instructions:
```
cd wasm_support_check
npm install
npm run start
```
Open address in browser.